### PR TITLE
TDALL-121 - Add support for listdata (search list using data criteria) functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>joor-java-8</artifactId>
             <version>0.9.12</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <version>2.6.3</version>
+        </dependency>
 
     </dependencies>
     <build>

--- a/src/main/java/ie/curiositysoftware/datacatalogue/dto/DataListItemDto.java
+++ b/src/main/java/ie/curiositysoftware/datacatalogue/dto/DataListItemDto.java
@@ -1,0 +1,53 @@
+package ie.curiositysoftware.datacatalogue;
+
+public class DataListItemDto
+{
+    private Long id;
+    private String value;
+    private Long columnId;
+    private String columnName;
+    private Long rowId;
+
+    public DataListItemDto() {
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public Long getColumnId() {
+        return this.columnId;
+    }
+
+    public String getColumnName() {
+        return this.columnName;
+    }
+
+    public Long getRowId() {
+        return this.rowId;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+    public void setColumnId(final Long columnId) {
+        this.columnId = columnId;
+    }
+
+    public void setColumnName(final String columnName) {
+        this.columnName = columnName;
+    }
+
+    public void setRowId(final Long rowId) {
+        this.rowId = rowId;
+    }
+}

--- a/src/main/java/ie/curiositysoftware/datacatalogue/dto/DataListRowDto.java
+++ b/src/main/java/ie/curiositysoftware/datacatalogue/dto/DataListRowDto.java
@@ -1,0 +1,46 @@
+package ie.curiositysoftware.datacatalogue;
+
+import java.util.List;
+
+public class DataListRowDto
+{
+    private Long id;
+    private Integer index;
+    private Long listId;
+    private List<DataListItemDto> items;
+
+    public DataListRowDto() {
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public Integer getIndex() {
+        return this.index;
+    }
+
+    public Long getListId() {
+        return this.listId;
+    }
+
+    public List<DataListItemDto> getItems() {
+        return this.items;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public void setIndex(final Integer index) {
+        this.index = index;
+    }
+
+    public void setListId(final Long listId) {
+        this.listId = listId;
+    }
+
+    public void setItems(final List<DataListItemDto> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/ie/curiositysoftware/datacatalogue/services/DataCatalogueTestCriteriaExecutionService.java
+++ b/src/main/java/ie/curiositysoftware/datacatalogue/services/DataCatalogueTestCriteriaExecutionService.java
@@ -1,0 +1,101 @@
+package ie.curiositysoftware.datacatalogue.services;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import ie.curiositysoftware.allocation.dto.DataCatalogueTestCriteria;
+import ie.curiositysoftware.datacatalogue.DataListRowDto;
+import ie.curiositysoftware.jobengine.services.ConnectionProfile;
+
+import ie.curiositysoftware.utils.RestResponsePage;
+import org.apache.http.client.AuthCache;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+public class DataCatalogueTestCriteriaExecutionService {
+    ConnectionProfile m_ConnectionProfile;
+
+    String m_ErrorMessage;
+
+    public DataCatalogueTestCriteriaExecutionService(ConnectionProfile connectionProfile)
+    {
+        m_ConnectionProfile = connectionProfile;
+    }
+
+    static String urlEncodeUTF8(String s) {
+        try {
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+    static String urlEncodeUTF8(Map<?,?> map) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<?,?> entry : map.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append("&");
+            }
+            sb.append(String.format("%s=%s",
+                    urlEncodeUTF8(entry.getKey().toString()),
+                    urlEncodeUTF8(entry.getValue().toString())
+            ));
+        }
+        return sb.toString();
+    }
+
+
+    public PageImpl<DataListRowDto> GetDataListRows( Long catalogueId, Long criteriaId, Pageable pageable, Map<String, String> parameters)
+    {
+        try {
+            String queryString = "";
+            if (parameters != null && parameters.size() > 0) {
+                queryString = parameters.entrySet().stream()
+                        .map(p -> urlEncodeUTF8(p.getKey()) + "=" + urlEncodeUTF8(p.getValue()))
+                        .reduce((p1, p2) -> p1 + "&" + p2)
+                        .orElse("");
+            }
+            if (pageable != null)
+            {
+                queryString = queryString + "page=" + pageable.getPageNumber() + "&size=" + pageable.getPageSize();
+            }
+
+
+            HttpResponse<com.fasterxml.jackson.databind.JsonNode> postResponse = Unirest.get(m_ConnectionProfile.getAPIUrl() + "/api/apikey/" + m_ConnectionProfile.getAPIKey() + "/data-catalogue/" + catalogueId + "/test-criteria/" + criteriaId + "/listdata?" + queryString)
+                    .header("accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    //.asJson();
+                    .asObject(com.fasterxml.jackson.databind.JsonNode.class);
+
+            if (postResponse.getStatus() == 200) {
+                com.fasterxml.jackson.databind.JsonNode node = postResponse.getBody();
+                ObjectMapper objectMapper = new ObjectMapper();
+                ObjectReader reader = objectMapper.readerFor(new TypeReference<RestResponsePage<DataListRowDto>>() { });
+
+                return reader.readValue(node);
+            } else {
+                m_ErrorMessage = postResponse.getStatus() + " - " +  postResponse.getStatusText();
+
+                return null;
+            }
+        } catch (Exception e) {
+            m_ErrorMessage = e.getMessage();
+
+            e.printStackTrace();
+
+            return null;
+        }
+    }
+
+    public String getErrorMessage() {
+        return m_ErrorMessage;
+    }
+}

--- a/src/main/java/ie/curiositysoftware/utils/PageImplToHashMap.java
+++ b/src/main/java/ie/curiositysoftware/utils/PageImplToHashMap.java
@@ -1,0 +1,44 @@
+package ie.curiositysoftware.utils;
+
+import ie.curiositysoftware.datacatalogue.DataListItemDto;
+import ie.curiositysoftware.datacatalogue.DataListRowDto;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PageImplToHashMap {
+
+    public PageImplToHashMap()
+    {
+
+    }
+
+    public List<HashMap<String, String>> convert(PageImpl<DataListRowDto> pageItems)
+    {
+        ArrayList<HashMap<String, String>> dataItems = new ArrayList<>();
+
+        if (pageItems.isEmpty())
+        {
+            return dataItems;
+        }
+
+        for (DataListRowDto rowDto : pageItems.toList())
+        {
+            HashMap<String, String> items = new HashMap<>();
+
+            for (DataListItemDto rowItem : rowDto.getItems())
+            {
+                if (!items.containsKey(rowItem.getColumnName())) {
+                    items.put(rowItem.getColumnName(), rowItem.getValue());
+                }
+            }
+
+            dataItems.add(items);
+        }
+
+        return  dataItems;
+    }
+}

--- a/src/main/java/ie/curiositysoftware/utils/RestResponsePage.java
+++ b/src/main/java/ie/curiositysoftware/utils/RestResponsePage.java
@@ -1,0 +1,37 @@
+package ie.curiositysoftware.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RestResponsePage<T> extends PageImpl<T> {
+
+    private static final long serialVersionUID = 3248189030448292002L;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestResponsePage(@JsonProperty("content") List<T> content, @JsonProperty("number") int number, @JsonProperty("size") int size,
+                            @JsonProperty("totalElements") Long totalElements, @JsonProperty("pageable") JsonNode pageable, @JsonProperty("last") boolean last,
+                            @JsonProperty("totalPages") int totalPages, @JsonProperty("sort") JsonNode sort, @JsonProperty("first") boolean first,
+                            @JsonProperty("numberOfElements") int numberOfElements, @JsonProperty("hasContent") boolean hasContent) {
+        super(content, PageRequest.of(number, size), totalElements);
+    }
+
+    public RestResponsePage(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+
+    public RestResponsePage(List<T> content) {
+        super(content);
+    }
+
+    public RestResponsePage() {
+        super(new ArrayList<T>());
+    }
+}


### PR DESCRIPTION
Usage:

        ConnectionProfile profile = new ConnectionProfile();
        profile.setAPIKey("lfK7tFyOp9rlimULrsw4CJjtD");
        profile.setAPIUrl("https://partner.testinsights.io");

        HashMap<String, String> mapData = new HashMap<>();
        mapData.put("parAge", "30");

        DataCatalogueTestCriteriaExecutionService service = new DataCatalogueTestCriteriaExecutionService(profile);
        PageImpl<DataListRowDto> rows = service.GetDataListRows(new Long(1), new Long(282), null, mapData);

        // if conversion to list of hash map is required to make it easier for end user
        PageImplToHashMap rowConverter = new PageImplToHashMap();
        List<HashMap<String, String>> rowItems = rowConverter.convert(rows);
